### PR TITLE
Adding camera type switching funcionality and image from gallery selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "expo-media-library": "~14.1.0",
     "expo-sharing": "~10.2.0",
     "expo-status-bar": "~1.3.0",
-    "phosphor-react-native": "^1.1.2",
     "hex-rgb": "^5.0.0",
+    "phosphor-react-native": "^1.1.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-native": "0.68.2",
@@ -30,12 +30,14 @@
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
     "react-native-svg": "12.3.0",
-    "react-native-svg-uri": "^1.2.3",
+    "react-native-svg-uri": "^0.0.1",
     "react-native-vector-icons": "^9.2.0",
     "react-native-web": "0.17.7",
     "react-redux": "^8.0.2",
     "redux": "^4.2.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "expo-image-picker": "~13.1.1",
+    "expo-file-system": "~14.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -1,140 +1,196 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button } from 'react-native';
+import React, { useState, useEffect, useRef } from "react";
+import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button } from "react-native";
 
-import { Camera, CameraType,  } from 'expo-camera';
-import { shareAsync } from 'expo-sharing';
-import * as MediaLibrary from 'expo-media-library';
+import { Camera, CameraType } from "expo-camera";
+import * as MediaLibrary from "expo-media-library";
+import * as ImagePicker from "expo-image-picker";
+import * as FileSystem from "expo-file-system";
 
-import IconVector from 'react-native-vector-icons/AntDesign';
-import * as IconPhosphor from 'phosphor-react-native';
+import * as IconPhosphor from "phosphor-react-native";
 
 export default function CameraModal({ navigation, modalVisible, setVisible }) {
-
   let camRef = useRef();
 
   const [hasCameraPermission, setHasCameraPermission] = useState();
   const [hasMediaLibraryPermission, setHasMediaLibraryPermission] = useState();
   const [photo, setPhoto] = useState();
 
-  const [type, setType] = useState(CameraType.front);
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [camType, setCamType] = useState(CameraType.back);
   const [flash, setFlash] = useState(Camera.Constants.FlashMode.off);
 
   useEffect(() => {
-    (async () => {
 
+    (async () => {
       const camPermission = await Camera.requestCameraPermissionsAsync();
       const mediaLibPermission = await MediaLibrary.requestPermissionsAsync();
 
-      setHasCameraPermission(camPermission.status==="granted");
-      setHasMediaLibraryPermission(mediaLibPermission.status==="granted");
+      setHasCameraPermission(camPermission.status === "granted");
+      setHasMediaLibraryPermission(mediaLibPermission.status === "granted");
 
-    })()
-  }, [])
+    })();
+  }, []);
 
   if (hasCameraPermission === null) {
-    return <View />
+    return <View />;
   }
 
   if (hasCameraPermission === false) {
-    return <Text>Sem permissão para usar a câmera</Text>
+    return <Text>Sem permissão para usar a câmera</Text>;
   }
 
-  const _toggleFlash = () => {
+  const toggleFlash = () => {
 
-    setFlash( flash === Camera.Constants.FlashMode.off ? Camera.Constants.FlashMode.on : Camera.Constants.FlashMode.off);
+    setFlash(
+      flash === Camera.Constants.FlashMode.off ? Camera.Constants.FlashMode.on : Camera.Constants.FlashMode.off
 
-  }
+    );
+
+  };
 
   let takePic = async () => {
 
     let options = {
 
       quality: 1,
-      base64: true,
-      exif: false
+      base64: false,
+      exif: false,
 
-    }
+    };
 
     let newPhoto = await camRef.current.takePictureAsync(options);
     setPhoto(newPhoto);
 
-  }
+  };
 
-  if (photo){
+  if (photo) {
 
     let savePhoto = () => {
 
-      MediaLibrary.saveToLibraryAsync(photo.uri).then( () => {
+      MediaLibrary.saveToLibraryAsync(photo.uri).then(() => {
 
-        setPhoto(undefined)
+        setPhoto(undefined);
 
-      })
+      });
 
-    }
+    };
 
     return (
 
-      <SafeAreaView>
-        <Image source={{uri: "data:image/jpg;base64," + photo.base64}}/>
-        { hasMediaLibraryPermission ? <Button title="Salvar" onPress={savePhoto}/> : <Text>Ative a permissão para salvar imagens!</Text>}
+      <SafeAreaView style={styles.container}>
+        <Image source={{ uri: photo.uri }} style={styles.preview}/>
+          { hasMediaLibraryPermission ? ( <Button title="Salvar" onPress={savePhoto} /> ) : ( <Text> Ative a permissão de acessar a biblioteca de mídias para salvar imagens! </Text> )}
         <Button title="Apagar" onPress={() => setPhoto(undefined)} />
       </SafeAreaView>
 
-    )
+    );
+
+  }
+
+  const selectImage = async () => {
+
+    let res = await ImagePicker.launchImageLibraryAsync({
+
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 1,
+      allowsEditing: true,
+
+    });
+
+    if (!res.cancelled) {
+
+      setSelectedImage(result.uri);
+
+    }
+
+  };
+
+  const switchCameraType = () => {
+
+    if(camType === 'back'){
+
+      setCamType('front')
+
+    }else{
+
+      setCamType('back')
+
+    }
 
   }
 
   return (
 
-    <Modal animationType='slide' visible={modalVisible} onRequestClose={() => setVisible(false)}>      
+    <Modal animationType="slide" visible={modalVisible} onRequestClose={() => setVisible(false)}>
       <SafeAreaView style={styles.container}>
-        <Camera style={styles.camera} type={type} flashMode={flash} ref={camRef}>
-          <View style={styles.buttonView}>
-              <TouchableOpacity onPress={takePic}>
-                  <IconPhosphor.Camera size={60} color='#fff'/>
+        <Camera style={styles.camera} type={camType} flashMode={flash} ref={camRef}>
+          <View style={styles.headerCam}>
+            <TouchableOpacity onPress={() => { navigation.navigate("Home"); }}>
+              <IconPhosphor.X size={60} color="#fff" />
+            </TouchableOpacity>
+              <TouchableOpacity onPress={switchCameraType}>
+                <IconPhosphor.ArrowsClockwise size={60} color="#fff" />
               </TouchableOpacity>
-            <TouchableOpacity onPress={() => _toggleFlash()}>
-              {
-                flash === Camera.Constants.FlashMode.on ? <IconPhosphor.Lightning size={60} color={"#fff"} /> : <IconPhosphor.LightningSlash size={60} color={"#fff"} />
-              }
+          </View>
+          <View style={styles.buttonView}>
+            <TouchableOpacity onPress={selectImage}>
+              <IconPhosphor.Image size={60} color="#fff" />
+            </TouchableOpacity>
+            <TouchableOpacity onPress={takePic}>
+              <IconPhosphor.Camera size={60} color="#fff" />
+            </TouchableOpacity>
+            <TouchableOpacity onPress={() => toggleFlash()}>
+              {flash === Camera.Constants.FlashMode.on ? ( <IconPhosphor.Lightning size={60} color={"#fff"} /> ) : ( <IconPhosphor.LightningSlash size={60} color={"#fff"} /> )}
             </TouchableOpacity>
           </View>
         </Camera>
       </SafeAreaView>
     </Modal>
-
-  )}
-
+  );
+}
 
 const styles = StyleSheet.create({
-
   container: {
 
-    flex: 1
+    flex: 1,
+
+  },
+  headerCam: {
+
+    flexDirection: 'row',
+    padding: 20,
+    width: Dimensions.get("window").width,
+    justifyContent: 'space-between'
 
   },
   camera: {
-
+    
     flex: 1,
-    height: Dimensions.get('window').height,
-    width: Dimensions.get('window').height * 3.1 / 4
+    height: Dimensions.get("window").height,
+    width: "100%"
 
   },
   buttonView: {
 
     flex: 1,
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-    padding: 50
+    width: Dimensions.get("window").width,
+    height: Dimensions.get("window").height,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "flex-end",
+    padding: 50,
 
   },
   phosphorFlash: {
 
-    alignItems: 'center'
+    alignItems: "center",
+
+  },
+  preview: {
+
+    alignSelf: 'stretch',
+    flex: 1
 
   }
 
-})
+});

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -4,7 +4,6 @@ import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensio
 import { Camera, CameraType } from "expo-camera";
 import * as MediaLibrary from "expo-media-library";
 import * as ImagePicker from "expo-image-picker";
-import * as FileSystem from "expo-file-system";
 
 import * as IconPhosphor from "phosphor-react-native";
 
@@ -129,7 +128,7 @@ export default function CameraModal({ navigation, modalVisible, setVisible }) {
               <IconPhosphor.X size={60} color="#fff" />
             </TouchableOpacity>
               <TouchableOpacity onPress={switchCameraType}>
-                <IconPhosphor.ArrowsClockwise size={60} color="#fff" />
+                {camType === 'front' ? ( <IconPhosphor.ArrowsClockwise size={60} color="#fff" /> ) : ( <IconPhosphor.ArrowsCounterClockwise size={60} color={"#fff"} /> )}
               </TouchableOpacity>
           </View>
           <View style={styles.buttonView}>


### PR DESCRIPTION
Nesse Pull Request, eu adiciono a funcionalidade de trocar o tipo da câmera entre a Frontal e a Traseira:

![image](https://user-images.githubusercontent.com/62211442/182046181-d3ea708c-8270-404b-8f8e-acb46453697a.png) - frontal.

![image](https://user-images.githubusercontent.com/62211442/182046205-8e25876c-58d4-486e-b4e3-65a9bc667562.png) - traseira.

E também a possibilidade de adicionar uma imagem a partir da galeria:

![image](https://user-images.githubusercontent.com/62211442/182046283-afbde2de-175c-483c-bf8f-07fcd4f634b8.png) - botão para abrir a galeria.
![image](https://user-images.githubusercontent.com/62211442/182046252-92ea3255-0728-4c93-a928-0d831e8e6b56.png) - galeria aberta após clicar no botão.

Também foi adicionada uma nova biblioteca (library) para a confecção da funcionalidade da galeria:

1. ImagePicker (expo-image-picker) 