### PR TITLE
Zoom capability & Camera modal changes depending on the phone's OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "color-convert": "^2.0.1",
     "expo": "~45.0.0",
     "expo-camera": "~12.2.0",
+    "expo-file-system": "~14.0.0",
+    "expo-image-picker": "~13.1.1",
     "expo-media-library": "~14.1.0",
     "expo-sharing": "~10.2.0",
     "expo-status-bar": "~1.3.0",
@@ -37,8 +39,7 @@
     "react-redux": "^8.0.2",
     "redux": "^4.2.0",
     "styled-components": "^5.3.5",
-    "expo-image-picker": "~13.1.1",
-    "expo-file-system": "~14.0.0"
+    "react-native-reanimated": "~2.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button, Animated } from "react-native";
+import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button, Animated, Platform } from "react-native";
 
 import { Camera, CameraType } from "expo-camera";
 import * as MediaLibrary from "expo-media-library";
 import * as ImagePicker from "expo-image-picker";
 
 import * as IconPhosphor from "phosphor-react-native";
-import { PinchGestureHandler } from "react-native-gesture-handler";
 
 export default function CameraModal({ navigation, modalVisible, setVisible }) {
   let camRef = useRef();
@@ -121,34 +120,106 @@ export default function CameraModal({ navigation, modalVisible, setVisible }) {
 
   }
 
+  const zoomScalePlus = () => {
+
+    let x = 0.005
+
+    if(!zoomScale){
+
+      setZoomScale(0);
+
+    }
+
+    x = x + zoomScale
+
+    if(!x){
+
+      setZoomScale(0);
+
+    }
+
+    setZoomScale(x);
+
+    if(zoomScale>=0.02){
+
+      setZoomScale(0.02);
+
+    }
+
+  }
+
+  const zoomScaleMinus = () => {
+
+    let x = -0.005
+
+    if(!zoomScale){
+
+      setZoomScale(0);
+
+    }
+
+    if(zoomScale>0){
+
+      if(!x){
+
+        setZoomScale(0);
+  
+      }
+
+      x = x + zoomScale
+      setZoomScale(x);
+
+    }else if(zoomScale<=0){
+
+      setZoomScale(0)
+
+    }
+
+  }
+
+
+  function CamBody(){
+
+    return(
+
+      <Camera style={styles.camera} type={camType} flashMode={flash} ref={camRef} zoom={zoomScale}>
+        <View style={styles.headerCam}>
+          <TouchableOpacity onPress={() => { navigation.navigate("Home"); }}>
+            <IconPhosphor.X size={60} color="#fff" />
+          </TouchableOpacity>
+          <View style={styles.zoomButton}>
+            <TouchableOpacity onPress={zoomScalePlus} >
+              <IconPhosphor.Plus size={35} color="#fff" />
+            </TouchableOpacity>
+            <TouchableOpacity onPress={zoomScaleMinus}>
+              <IconPhosphor.Minus size={35} color="#fff" />
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity onPress={switchCameraType}>
+            {camType === 'front' ? ( <IconPhosphor.ArrowsClockwise size={60} color="#fff" /> ) : ( <IconPhosphor.ArrowsCounterClockwise size={60} color={"#fff"} /> )}
+          </TouchableOpacity>
+        </View>
+        <View style={styles.buttonView}>
+          <TouchableOpacity onPress={selectImage}>
+            <IconPhosphor.Image size={60} color="#fff" />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={takePic}>
+              <IconPhosphor.Camera size={60} color="#fff" style={{display: 'inline-block', borderRadius: '60px', boxShadow: '0 0 6px #888'}} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => toggleFlash()}>
+            {flash === Camera.Constants.FlashMode.on ? ( <IconPhosphor.Lightning size={60} color={"#fff"} /> ) : ( <IconPhosphor.LightningSlash size={60} color={"#fff"} /> )}
+          </TouchableOpacity>
+        </View>
+      </Camera>
+
+    )
+
+  }
+
   return (
     
     <Modal animationType="slide" visible={modalVisible} onRequestClose={() => setVisible(false)}>
-      <View style={styles.container}>
-        <PinchGestureHandler>
-          <Camera style={styles.camera} type={camType} flashMode={flash} ref={camRef} zoom={zoomScale}>
-              <View style={styles.headerCam}>
-                <TouchableOpacity onPress={() => { navigation.navigate("Home"); }}>
-                  <IconPhosphor.X size={60} color="#fff" />
-                </TouchableOpacity>
-                <TouchableOpacity onPress={switchCameraType}>
-                  {camType === 'front' ? ( <IconPhosphor.ArrowsClockwise size={60} color="#fff" /> ) : ( <IconPhosphor.ArrowsCounterClockwise size={60} color={"#fff"} /> )}
-                </TouchableOpacity>
-              </View>
-              <View style={styles.buttonView}>
-                <TouchableOpacity onPress={selectImage}>
-                  <IconPhosphor.Image size={60} color="#fff" />
-                </TouchableOpacity>
-                <TouchableOpacity onPress={takePic}>
-                    <IconPhosphor.Camera size={60} color="#fff" style={{display: 'inline-block', borderRadius: '60px', boxShadow: '0 0 2px #888', padding: '1em 1em'}} />
-                </TouchableOpacity>
-                <TouchableOpacity onPress={() => toggleFlash()}>
-                  {flash === Camera.Constants.FlashMode.on ? ( <IconPhosphor.Lightning size={60} color={"#fff"} /> ) : ( <IconPhosphor.LightningSlash size={60} color={"#fff"} /> )}
-                </TouchableOpacity>
-              </View>
-            </Camera>
-          </PinchGestureHandler>
-      </View>
+      { Platform.OS === 'ios' ? (<View style={styles.container}><CamBody/></View>) : (<SafeAreaView style={styles.container}><CamBody/></SafeAreaView>) }
     </Modal>
     
   );
@@ -166,6 +237,14 @@ const styles = StyleSheet.create({
     padding: 20,
     width: Dimensions.get("window").width,
     justifyContent: 'space-between'
+
+  },
+  zoomButton: {
+
+    flexDirection: 'row',
+    padding: 25,
+    justifyContent: 'space-between',
+    width: 180
 
   },
   camera: {

--- a/src/components/Camera.jsx
+++ b/src/components/Camera.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button } from "react-native";
+import { Modal, Text, View, StyleSheet, SafeAreaView, TouchableOpacity, Dimensions, Image, Button, Animated } from "react-native";
 
 import { Camera, CameraType } from "expo-camera";
 import * as MediaLibrary from "expo-media-library";
 import * as ImagePicker from "expo-image-picker";
 
 import * as IconPhosphor from "phosphor-react-native";
+import { PinchGestureHandler } from "react-native-gesture-handler";
 
 export default function CameraModal({ navigation, modalVisible, setVisible }) {
   let camRef = useRef();
@@ -13,10 +14,12 @@ export default function CameraModal({ navigation, modalVisible, setVisible }) {
   const [hasCameraPermission, setHasCameraPermission] = useState();
   const [hasMediaLibraryPermission, setHasMediaLibraryPermission] = useState();
   const [photo, setPhoto] = useState();
+  
 
   const [selectedImage, setSelectedImage] = useState(null);
   const [camType, setCamType] = useState(CameraType.back);
   const [flash, setFlash] = useState(Camera.Constants.FlashMode.off);
+  const [zoomScale, setZoomScale] = useState(0)
 
   useEffect(() => {
 
@@ -119,32 +122,35 @@ export default function CameraModal({ navigation, modalVisible, setVisible }) {
   }
 
   return (
-
+    
     <Modal animationType="slide" visible={modalVisible} onRequestClose={() => setVisible(false)}>
-      <SafeAreaView style={styles.container}>
-        <Camera style={styles.camera} type={camType} flashMode={flash} ref={camRef}>
-          <View style={styles.headerCam}>
-            <TouchableOpacity onPress={() => { navigation.navigate("Home"); }}>
-              <IconPhosphor.X size={60} color="#fff" />
-            </TouchableOpacity>
-              <TouchableOpacity onPress={switchCameraType}>
-                {camType === 'front' ? ( <IconPhosphor.ArrowsClockwise size={60} color="#fff" /> ) : ( <IconPhosphor.ArrowsCounterClockwise size={60} color={"#fff"} /> )}
-              </TouchableOpacity>
-          </View>
-          <View style={styles.buttonView}>
-            <TouchableOpacity onPress={selectImage}>
-              <IconPhosphor.Image size={60} color="#fff" />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={takePic}>
-              <IconPhosphor.Camera size={60} color="#fff" />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={() => toggleFlash()}>
-              {flash === Camera.Constants.FlashMode.on ? ( <IconPhosphor.Lightning size={60} color={"#fff"} /> ) : ( <IconPhosphor.LightningSlash size={60} color={"#fff"} /> )}
-            </TouchableOpacity>
-          </View>
-        </Camera>
-      </SafeAreaView>
+      <View style={styles.container}>
+        <PinchGestureHandler>
+          <Camera style={styles.camera} type={camType} flashMode={flash} ref={camRef} zoom={zoomScale}>
+              <View style={styles.headerCam}>
+                <TouchableOpacity onPress={() => { navigation.navigate("Home"); }}>
+                  <IconPhosphor.X size={60} color="#fff" />
+                </TouchableOpacity>
+                <TouchableOpacity onPress={switchCameraType}>
+                  {camType === 'front' ? ( <IconPhosphor.ArrowsClockwise size={60} color="#fff" /> ) : ( <IconPhosphor.ArrowsCounterClockwise size={60} color={"#fff"} /> )}
+                </TouchableOpacity>
+              </View>
+              <View style={styles.buttonView}>
+                <TouchableOpacity onPress={selectImage}>
+                  <IconPhosphor.Image size={60} color="#fff" />
+                </TouchableOpacity>
+                <TouchableOpacity onPress={takePic}>
+                    <IconPhosphor.Camera size={60} color="#fff" style={{display: 'inline-block', borderRadius: '60px', boxShadow: '0 0 2px #888', padding: '1em 1em'}} />
+                </TouchableOpacity>
+                <TouchableOpacity onPress={() => toggleFlash()}>
+                  {flash === Camera.Constants.FlashMode.on ? ( <IconPhosphor.Lightning size={60} color={"#fff"} /> ) : ( <IconPhosphor.LightningSlash size={60} color={"#fff"} /> )}
+                </TouchableOpacity>
+              </View>
+            </Camera>
+          </PinchGestureHandler>
+      </View>
     </Modal>
+    
   );
 }
 


### PR DESCRIPTION
Nesse PR, faço a adição da capacidade de dar zoom e/ou tirar o zoom da câmera.

https://user-images.githubusercontent.com/62211442/183157316-7e3111a8-b951-4239-bf36-afaf176ed18c.MP4

Acabei não precisando de nenhuma biblioteca para confeccionar essas novas features.

Também adicionei a feature de dependendo do Sistema Operacional do celular, o modal da câmera vai se alterar;

Caso o celular tenha iOS, o modal da câmera vai se acomodar ocupando a tela inteira, ou seja, vai incluir os pequenos "chifrinhos" (notch) que os iPhones pós-X têm:

![image](https://user-images.githubusercontent.com/62211442/183158027-cc546bfb-2916-4f0b-8da4-4f39a9260ba2.png)

Caso seja Android, o modal da câmera, só vai se acomudar ocupando a parte "real" da tela do celular, ou seja, aqueles celulares que tem chifrinhos não vão ter toda a área ocupada como os iPhones terão e mostrarão os status do celular:

![image](https://user-images.githubusercontent.com/62211442/183158485-85272648-1fc7-44ac-afdf-9184de9e7cca.png)


